### PR TITLE
Fix compile errors on master

### DIFF
--- a/src/main/java/org/ilite/frc/common/util/SystemUtils.java
+++ b/src/main/java/org/ilite/frc/common/util/SystemUtils.java
@@ -42,7 +42,8 @@ public class SystemUtils {
   public static <V extends Number, E extends Enum<E> & CodexOf<V>> void writeCodexToSmartDashboard(Codex<V, E> pCodex) {
     List<E> enums = EnumUtils.getSortedEnums(pCodex.meta().getEnum());
     for(E e : enums) {
-      SmartDashboard.putNumber(e.toString(), (double) pCodex.get(e));
+      Double value = (Double) pCodex.get(e);
+      if(e != null) SmartDashboard.putNumber(e.toString(), (value == null) ? 0 : value);
     }
   }
 }

--- a/src/main/java/org/ilite/frc/robot/Robot.java
+++ b/src/main/java/org/ilite/frc/robot/Robot.java
@@ -23,10 +23,6 @@ import com.flybotix.hfr.util.log.ELevel;
 import com.flybotix.hfr.util.log.ILog;
 import com.flybotix.hfr.util.log.Logger;
 
-import edu.wpi.first.networktables.NetworkTableInstance;
-
-import edu.wpi.first.wpilibj.GenericHID.RumbleType;
-
 import edu.wpi.first.wpilibj.IterativeRobot;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.PowerDistributionPanel;
@@ -54,8 +50,10 @@ public class Robot extends IterativeRobot {
   private final DriverControl drivetraincontrol;
 
   public Robot() {
+    elevator = new ElevatorModule();
+    intake = new Intake(elevator);
   	mControlLoop = new ControlLoopManager(mData, mHardware);
-  	drivetraincontrol = new DriverControl(mData);
+  	drivetraincontrol = new DriverControl(mData, intake, elevator);
   	dt = new DriveTrain(drivetraincontrol);
   	getAutonomous = new GetAutonomous(SystemSettings.AUTON_TABLE);
   	Logger.setLevel(ELevel.INFO);

--- a/src/main/java/org/ilite/frc/robot/modules/DriverControl.java
+++ b/src/main/java/org/ilite/frc/robot/modules/DriverControl.java
@@ -73,9 +73,9 @@ public class DriverControl implements IModule{
 		double intakeSpeed = mData.operator.get(ELogitech310.RIGHT_Y_AXIS);
 		
 		if (mData.operator.get(ELogitech310.DPAD_DOWN) != null)
-			mIntake.setIntakePneumatics(false);
+			mIntake.setIntakePneumaticsOut(false);
 		if (mData.operator.get(ELogitech310.DPAD_UP) != null)
-			mIntake.setIntakePneumatics(true);
+			mIntake.setIntakePneumaticsOut(true);
 		
 		if(intakeSpeed > 0) {
 			mIntake.intakeIn(intakeSpeed);


### PR DESCRIPTION
Fixes incorrect method calls to intake, incomplete DriverControl constructor, and NullPointerException in writeCodexToSmartDashboard(). Master should compile correctly after this fix.